### PR TITLE
Add plan tech name to header

### DIFF
--- a/src/Dfe.ContentSupport.Web/Views/Shared/_CsHeader.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_CsHeader.cshtml
@@ -7,4 +7,7 @@
             </a>
         </div>
     </div>
+    <div class="dfe-width-container dfe-header__service-name">
+        <a href="/self-assessment" class="dfe-header__link--service">Plan technology for your school</a>
+    </div>
 </div>


### PR DESCRIPTION
Update service name in header to "Plan technology for your school". I kept this an `<a>` pointing at `/self-assessment`, despite the fact that the route doesn't exist within C&S, to remain consistent with the header in PT. 

Worth considering whether we need our own header at all now, although keeping it might make future name changes easier?