### PR TITLE
fix(print): Move Javascript to <script> element due to CSP

### DIFF
--- a/src/Dfe.ContentSupport.Web/Views/Content/CsIndex.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Content/CsIndex.cshtml
@@ -52,3 +52,28 @@
         }
     </div>
 </div>
+
+@section BodyEnd{
+    @if (Model.HasPrint)
+    {
+        <script nonce="@Context.Items["nonce"]" defer>
+            /**
+            * Adds functionality for printing a page to the Print Page button (_Print.cshtml)
+            */
+            const printPage = () => window.print();
+
+
+            const addPrintButtonEventListener = () => {
+                const printButton = document.getElementById("print-link");
+
+                if(!printButton){
+                    return;
+                }
+
+                printButton.addEventListener('click', printPage);
+            }
+
+            addPrintButtonEventListener();
+        </script>
+    }
+}

--- a/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
@@ -1,3 +1,3 @@
 ﻿<div class="print-button">
-    <button class="govuk-link print-link-button" data-module="print-link" onclick="window.print()">Print this page</button>
+    <button class="govuk-link print-link-button" data-module="print-link" id="print-link">Print this page</button>
 </div>


### PR DESCRIPTION
The print button wasn't working when hosted on PT, due to the content security policy.

This PR:
1. Removes the in-line `window.print()` functionality
2. Moves it to a separate `script` element, with a nonce (to pass the CSP)