### PR TITLE
feat: Hide JS dependant elements unless JS enabled

### DIFF
--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -55,7 +55,7 @@ jobs:
         /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
         /d:sonar.host.url="https://sonarcloud.io" \
         /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml \
-        /d:sonar.coverage.exclusions=**/Program.cs,**/wwwroot/** \
+        /d:sonar.coverage.exclusions=**/Program.cs,**/wwwroot/**,**/Dfe.ContentSupport.Web.E2ETests/** \
         /d:sonar.issue.ignore.multicriteria=e1 \
         /d:sonar.issue.ignore.multicriteria.e1.ruleKey=csharpsquid:S6602 \
         /d:sonar.issue.ignore.multicriteria.e1.resourceKey=src/**/*.cs

--- a/src/Dfe.ContentSupport.Web/Views/Content/CsIndex.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Content/CsIndex.cshtml
@@ -52,3 +52,28 @@
         }
     </div>
 </div>
+
+@section BodyEnd{
+    @if (Model.HasPrint)
+    {
+        <script nonce="@Context.Items["nonce"]" defer>
+            /**
+            * Adds functionality for printing a page to the Print Page button (_Print.cshtml)
+            */
+            const printPage = () => window.print();
+
+
+            const addPrintButtonEventListener = () => {
+                const printButton = document.getElementById("print-link");
+
+                if(!printButton){
+                    return;
+                }
+
+                printButton.addEventListener('click', printPage);
+            }
+
+            addPrintButtonEventListener();
+        </script>
+    }
+}

--- a/src/Dfe.ContentSupport.Web/Views/Content/CsIndex.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Content/CsIndex.cshtml
@@ -76,4 +76,28 @@
             addPrintButtonEventListener();
         </script>
     }
+
+    <script nonce="@Context.Items["nonce"]" defer>
+        const hiddenClass = "govuk-visually-hidden";
+
+        //Some elements should remain hidden
+        const idsToNotShow = ["support-links"];
+
+        //Remove hidden visibility CSS class if JS enabled
+        const removeHiddenClassFromElements = () => {
+            const hiddenElements = Array.from(document.querySelectorAll(`.${hiddenClass}`));
+
+            for(const element of hiddenElements){
+                if(idsToNotShow.indexOf(element.id) > -1){
+                    continue;
+                }
+
+                element.classList.remove(hiddenClass);
+                //Also unset "aria-hidden" attribute
+                element.ariaHidden = undefined;
+            }
+        }
+
+        removeHiddenClassFromElements();
+    </script>
 }

--- a/src/Dfe.ContentSupport.Web/Views/Shared/_Feedback.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_Feedback.cshtml
@@ -17,7 +17,7 @@
 
 @if (track)
 {
-    <div class="dfe-feedback-banner govuk-!-margin-top-9 govuk-visually-hidden" aria-hidden="true">
+    <div class="dfe-feedback-banner govuk-!-margin-top-9 govuk-visually-hidden" aria-hidden="true" id="feedback-banner">
         <div class="dfe-feedback-banner--content">
             <form id="feedbackForm">
                 <div class="dfe-feedback-banner--content-questions">

--- a/src/Dfe.ContentSupport.Web/Views/Shared/_Feedback.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_Feedback.cshtml
@@ -17,7 +17,7 @@
 
 @if (track)
 {
-    <div class="dfe-feedback-banner govuk-!-margin-top-9">
+    <div class="dfe-feedback-banner govuk-!-margin-top-9 govuk-visually-hidden" aria-hidden="true">
         <div class="dfe-feedback-banner--content">
             <form id="feedbackForm">
                 <div class="dfe-feedback-banner--content-questions">

--- a/src/Dfe.ContentSupport.Web/Views/Shared/_Footer.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_Footer.cshtml
@@ -1,8 +1,8 @@
 <footer class="govuk-footer " role="contentinfo">
-    <div class="govuk-width-container ">
+    <div class="govuk-width-container">
         <div class="govuk-footer__meta">
             <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-                <h2 class="govuk-visually-hidden">Support links</h2>
+                <h2 class="govuk-visually-hidden" id="support-links">Support links</h2>
                 @* @await Component.InvokeAsync("FooterLinks") *@
                 <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo"
                      xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">

--- a/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
@@ -1,3 +1,3 @@
 ﻿<div class="print-button">
-    <button class="govuk-link print-link-button" data-module="print-link" id="print-link">Print this page</button>
+    <button class="govuk-link print-link-button govuk-visually-hidden" data-module="print-link" id="print-link" aria-hidden="true">Print this page</button>
 </div>

--- a/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
@@ -1,3 +1,3 @@
 ﻿<div class="print-button">
-    <button class="govuk-link print-link-button" data-module="print-link" onclick="window.print()">Print this page</button>
+    <button class="govuk-link print-link-button" data-module="print-link" id="print-link">Print this page</button>
 </div>

--- a/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
@@ -1,3 +1,3 @@
-﻿<div class="print-button">
-    <button class="govuk-link print-link-button govuk-visually-hidden" data-module="print-link" id="print-link" aria-hidden="true">Print this page</button>
+﻿<div class="print-button govuk-visually-hidden" aria-hidden="true">
+    <button class="govuk-link print-link-button" data-module="print-link" id="print-link" >Print this page</button>
 </div>

--- a/tests/Dfe.ContentSupport.Web.E2ETests/cypress/e2e/pages/feedback.cy.js
+++ b/tests/Dfe.ContentSupport.Web.E2ETests/cypress/e2e/pages/feedback.cy.js
@@ -1,0 +1,30 @@
+describe('Feedback banner', () => {
+  it("should be visible when tracking consented", () => {
+    cy.visit('content/hello-world',
+      {
+        headers: {
+          'Cookie': '.AspNet.Consent=yes'
+        }
+      }
+    );
+
+    cy.get("div#feedback-banner")
+      .should('exist')
+      .not("govuk-visually-hidden")
+      .should('not.have.attr', 'aria-hidden');
+  });
+
+  it("should not exist when tracking consent not given", () => {
+    cy.visit('content/hello-world',
+      {
+        headers: {
+          'Cookie': '.AspNet.Consent=no'
+        }
+      }
+    );
+
+    cy.get("div#feedback-banner")
+      .should('not.exist');
+  });
+
+});

--- a/tests/Dfe.ContentSupport.Web.E2ETests/cypress/e2e/pages/print-button.cy.js
+++ b/tests/Dfe.ContentSupport.Web.E2ETests/cypress/e2e/pages/print-button.cy.js
@@ -1,0 +1,25 @@
+describe('Print button', () => {
+  beforeEach(() => {
+    cy.visit('content/hello-world', {
+      onBeforeLoad(win) {
+        //Stub the print functionality so we can see if it was called
+        //Note: could spy instead, but I don't want the print dialog to actually show.
+        cy.stub(win, 'print', () => { });
+      },
+    });
+  });
+
+  it("should be visible", () => {
+    cy.get("div.print-button")
+      .should('exist')
+      .not("govuk-visually-hidden")
+      .should('not.have.attr', 'aria-hidden');
+
+    cy.get("button#print-link").should("exist");
+  });
+
+  it("should print on click", () => {
+    cy.get("button#print-link").click();
+    cy.window().its("print").should('be.called');
+  });
+});


### PR DESCRIPTION
GDS guidelines are to not have functionality that _requires_ JS unless there's an alternative. If there is functionality that _needs_ JS, and there is no alternative, the practice is to hide it for non-JS users.

This PR:

1. Adds `govuk-visually-hidden` and `aria-hidden` to the Print button, and the Feedback section
2. Adds a script that finds all elements with the class `.govuk-visually-hidden`
3. For each element, it removes the class, and sets aria-hidden to undefined

It also ignores certain IDs (at the moment, just one), as the same class is also used in the Footer for the "Support Links" header; assumedly for accessibility.

**NOTE**: Forked from #148 - which should be merged in first.