### PR TITLE
feat(content): Add error handling + logging to content route

### DIFF
--- a/src/Dfe.ContentSupport.Web/Controllers/ContentController.cs
+++ b/src/Dfe.ContentSupport.Web/Controllers/ContentController.cs
@@ -33,13 +33,13 @@ public class ContentController(IContentService contentService, ILayoutService la
     {
         if (!ModelState.IsValid)
         {
-            logger.LogError("Invalid model state received for {Slug}", slug);
+            logger.LogError("Invalid model state received for {Controller} {Action} with slug {Slug}", nameof(ContentController), nameof(Index), slug);
             return RedirectToAction("error");
         }
 
         if (string.IsNullOrEmpty(slug))
         {
-            logger.LogError("No slug received for C&S {Controller} {Action} ", nameof(ContentController), nameof(Index));
+            logger.LogError("No slug received for C&S {Controller} {Action}", nameof(ContentController), nameof(Index));
             return RedirectToAction("error");
         }
 

--- a/src/Dfe.ContentSupport.Web/Controllers/ContentController.cs
+++ b/src/Dfe.ContentSupport.Web/Controllers/ContentController.cs
@@ -12,6 +12,8 @@ namespace Dfe.ContentSupport.Web.Controllers;
 public class ContentController(IContentService contentService, ILayoutService layoutService, ILogger<ContentController> logger)
     : Controller
 {
+    public const string ErrorActionName = "error";
+
     public async Task<IActionResult> Home()
     {
         var defaultModel = new CsPage
@@ -34,13 +36,13 @@ public class ContentController(IContentService contentService, ILayoutService la
         if (!ModelState.IsValid)
         {
             logger.LogError("Invalid model state received for {Controller} {Action} with slug {Slug}", nameof(ContentController), nameof(Index), slug);
-            return RedirectToAction("error");
+            return RedirectToAction(ErrorActionName);
         }
 
         if (string.IsNullOrEmpty(slug))
         {
             logger.LogError("No slug received for C&S {Controller} {Action}", nameof(ContentController), nameof(Index));
-            return RedirectToAction("error");
+            return RedirectToAction(ErrorActionName);
         }
 
         try
@@ -49,7 +51,7 @@ public class ContentController(IContentService contentService, ILayoutService la
             if (resp is null)
             {
                 logger.LogError("Failed to load content for C&S page {Slug}; no content received.", slug);
-                return RedirectToAction("error");
+                return RedirectToAction(ErrorActionName);
             }
 
             resp = layoutService.GenerateLayout(resp, Request, page);
@@ -60,7 +62,7 @@ public class ContentController(IContentService contentService, ILayoutService la
         catch (Exception ex)
         {
             logger.LogError(ex, "Error loading C&S content page {Slug}", slug);
-            return RedirectToAction("error");
+            return RedirectToAction(ErrorActionName);
         }
     }
 

--- a/tests/Dfe.ContentSupport.Web.Tests/Controllers/ContentControllerTests.cs
+++ b/tests/Dfe.ContentSupport.Web.Tests/Controllers/ContentControllerTests.cs
@@ -2,6 +2,7 @@
 using Dfe.ContentSupport.Web.Models.Mapped;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dfe.ContentSupport.Web.Tests.Controllers;
 
@@ -11,7 +12,7 @@ public class ContentControllerTests
 
     private ContentController GetController()
     {
-        return new ContentController(_contentServiceMock.Object, new LayoutService());
+        return new ContentController(_contentServiceMock.Object, new LayoutService(), new NullLogger<ContentController>());
     }
 
 

--- a/tests/Dfe.ContentSupport.Web.Tests/Controllers/ContentControllerTests.cs
+++ b/tests/Dfe.ContentSupport.Web.Tests/Controllers/ContentControllerTests.cs
@@ -2,17 +2,18 @@
 using Dfe.ContentSupport.Web.Models.Mapped;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Dfe.ContentSupport.Web.Tests.Controllers;
 
 public class ContentControllerTests
 {
+    private readonly Mock<ILogger<ContentController>> _loggerMock = new();
     private readonly Mock<IContentService> _contentServiceMock = new();
 
     private ContentController GetController()
     {
-        return new ContentController(_contentServiceMock.Object, new LayoutService(), new NullLogger<ContentController>());
+        return new ContentController(_contentServiceMock.Object, new LayoutService(), _loggerMock.Object);
     }
 
 
@@ -37,6 +38,15 @@ public class ContentControllerTests
 
         result.Should().BeOfType<RedirectToActionResult>();
         (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo("error");
+
+        _loggerMock.Verify(
+               x => x.Log(
+                   LogLevel.Error,
+                   It.IsAny<EventId>(),
+                   It.Is<It.IsAnyType>((o, t) => o.ToString() != null && o.ToString()!.StartsWith($"No slug received for C&S {nameof(ContentController)} {nameof(sut.Index)}")),
+                   It.IsAny<Exception>(),
+                   It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+               Times.Once);
     }
 
     [Fact]
@@ -54,15 +64,47 @@ public class ContentControllerTests
     [Fact]
     public async Task Index_NullResponse_ReturnsErrorAction()
     {
+        var slug = "slug";
         _contentServiceMock.Setup(o => o.GetContent(It.IsAny<string>(), It.IsAny<bool>()))
             .ReturnsAsync((CsPage?)null);
 
         var sut = GetController();
 
-        var result = await sut.Index("slug");
+        var result = await sut.Index(slug);
 
         result.Should().BeOfType<RedirectToActionResult>();
         (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo("error");
+
+        _loggerMock.Verify(x => x.Log(
+           LogLevel.Error,
+           It.IsAny<EventId>(),
+           It.Is<It.IsAnyType>((o, t) => o.ToString() != null && o.ToString()!.Equals($"Failed to load content for C&S page {slug}; no content received.")),
+           It.IsAny<Exception>(),
+           It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+       Times.Once);
+    }
+
+    [Fact]
+    public async Task Index_ExceptionThrown_ReturnsErrorAction()
+    {
+        var slug = "slug";
+        _contentServiceMock.Setup(o => o.GetContent(It.IsAny<string>(), It.IsAny<bool>()))
+            .ThrowsAsync(new Exception("An exception occurred loading content"));
+
+        var sut = GetController();
+
+        var result = await sut.Index(slug);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo("error");
+
+        _loggerMock.Verify(x => x.Log(
+           LogLevel.Error,
+           It.IsAny<EventId>(),
+           It.Is<It.IsAnyType>((o, t) => o.ToString() != null && o.ToString()!.Equals($"Error loading C&S content page {slug}")),
+           It.IsAny<Exception>(),
+           It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+       Times.Once);
     }
 
     [Fact]

--- a/tests/Dfe.ContentSupport.Web.Tests/Dfe.ContentSupport.Web.Tests.csproj
+++ b/tests/Dfe.ContentSupport.Web.Tests/Dfe.ContentSupport.Web.Tests.csproj
@@ -11,20 +11,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.3"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="Moq" Version="4.20.70"/>
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Dfe.ContentSupport.Web\Dfe.ContentSupport.Web.csproj"/>
+        <ProjectReference Include="..\..\src\Dfe.ContentSupport.Web\Dfe.ContentSupport.Web.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR:
1. Adds logging messages for various possible exceptions in the `Index` action on the `ContentController`
2. Adds very basic exception catching around retrieving the C&S page in the above. 
3. Replaces all instances of `"error"` in the `RedirectToAction`s for errors in the above controller, with a constant string
4. Adds/updates unit tests where appropriate