### PR TITLE
Fix/bleeding links

### DIFF
--- a/src/Dfe.ContentSupport.Web/Views/Shared/RichText/_HyperLink.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/RichText/_HyperLink.cshtml
@@ -2,11 +2,9 @@
 
 @if (Model.IsVimeo)
 {
-    <partial name="RichText/_Vimeo" model="@Model" />
+    <partial name="RichText/_Vimeo" model="@Model"/>
 }
 else
 {
-    <a href="@Model.Uri" target="_blank" rel="noopener noreferrer">
-        <partial name="RichText/_Items" model="@Model"/>
-    </a>
+    <a href="@Model.Uri" target="_blank" rel="noopener noreferrer"><partial name="RichText/_Text" model="@Model.Content.First()"/></a>
 }

--- a/src/Dfe.ContentSupport.Web/Views/Shared/_BetaHeader.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_BetaHeader.cshtml
@@ -3,10 +3,7 @@
         @* <govuk-phase-banner-tag>Beta</govuk-phase-banner-tag> *@
         <strong class="govuk-tag govuk-phase-banner__content__tag">Beta</strong>
         This is a new service - your
-        <a href="https://forms.office.com/e/Jk5PuNWvGe" class="govuk-link" target="_blank"
-        rel="noopener">
-            feedback
-        </a> will
+        <a href="https://forms.office.com/e/Jk5PuNWvGe" class="govuk-link" target="_blank" rel="noopener">feedback</a> will
         help us to improve it.
     </p>
 </div>


### PR DESCRIPTION
Fixed issue where hyperlinks were adding a whitespace after themselves. Partially caused by over zealous linter 