### PR TITLE
Chore: fix JS linting errors

### DIFF
--- a/tests/Dfe.ContentSupport.Web.E2ETests/cypress.config.js
+++ b/tests/Dfe.ContentSupport.Web.E2ETests/cypress.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents() {
       // implement node event listeners here
     },
     baseUrl: process.env.CYPRESS_BASE_URL || 'http://localhost:5265',


### PR DESCRIPTION
ESLint has been added to [Plan Tech](https://github.com/DFE-Digital/sts-plan-technology-for-your-school) and is catching unused variables on this project - this PR removes them